### PR TITLE
Fix Travis badge

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,5 +1,6 @@
 #+TITLE: Idris Test Utils
 
-[![Build Status](https://travis-ci.org/jfdm/idris-testing.svg?branch=master)](https://travis-ci.org/jfdm/idris-testing)
+#+ATTR_HTML: alt="Build Status"
+[[https://travis-ci.org/jfdm/idris-testing][file:https://travis-ci.org/jfdm/idris-testing.svg?branch=master]]
 
 Various utilities to aid in the testing of things in Idris.


### PR DESCRIPTION
It was using Markdown notation instead of Org.

N.B. It looks like GitHub doesn't support the `ATTR_HTML`, but I've confirmed that syntax is correct too.

See also: http://orgmode.org/worg/org-tutorials/images-and-xhtml-export.html#orgheadline3